### PR TITLE
[WIP] - Error logging

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -341,10 +341,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 523C4DWBTH;
+				DEVELOPMENT_TEAM = 8T736HH745;
 				INFOPLIST_FILE = Examples/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.Examples;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ehudadlerExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -357,10 +357,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 523C4DWBTH;
+				DEVELOPMENT_TEAM = 8T736HH745;
 				INFOPLIST_FILE = Examples/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.Examples;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ehudadlerExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Examples/Base.lproj/Main.storyboard
@@ -71,7 +71,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fre-XY-Ut7">
-                                <rect key="frame" x="87.5" y="461" width="200" height="40"/>
+                                <rect key="frame" x="87" y="470" width="200" height="40"/>
                                 <color key="backgroundColor" red="0.15686274510000001" green="0.65490196079999996" blue="0.27058823529999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="QCA-WD-Hwk"/>
@@ -85,7 +85,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nbe-Gl-p8R">
-                                <rect key="frame" x="87.5" y="413" width="200" height="40"/>
+                                <rect key="frame" x="87" y="422" width="200" height="40"/>
                                 <color key="backgroundColor" red="0.6888468861579895" green="0.13919923262595113" blue="0.11669686631770547" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -98,7 +98,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="nbe-Gl-p8R" firstAttribute="height" secondItem="fre-XY-Ut7" secondAttribute="height" id="6Uc-X6-YOh"/>
-                            <constraint firstItem="cyn-cy-XfB" firstAttribute="top" secondItem="fre-XY-Ut7" secondAttribute="bottom" constant="17" id="Mqa-gD-hxc"/>
+                            <constraint firstItem="cyn-cy-XfB" firstAttribute="top" secondItem="fre-XY-Ut7" secondAttribute="bottom" constant="8" id="Mqa-gD-hxc"/>
                             <constraint firstItem="fre-XY-Ut7" firstAttribute="top" secondItem="nbe-Gl-p8R" secondAttribute="bottom" constant="8" symbolic="YES" id="Qjs-ua-CcL"/>
                             <constraint firstItem="cyn-cy-XfB" firstAttribute="centerX" secondItem="83i-eb-xa2" secondAttribute="centerX" id="a9J-3N-hfT"/>
                             <constraint firstItem="spO-UG-XJt" firstAttribute="bottom" secondItem="cyn-cy-XfB" secondAttribute="bottom" constant="16" id="bac-or-OqW"/>

--- a/Examples/Examples/Base.lproj/Main.storyboard
+++ b/Examples/Examples/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kvB-Ba-BBN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kvB-Ba-BBN">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -57,7 +57,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cyn-cy-XfB">
-                                <rect key="frame" x="87" y="518" width="200" height="40"/>
+                                <rect key="frame" x="87.5" y="518" width="200" height="40"/>
                                 <color key="backgroundColor" red="0.1960784314" green="0.49019607840000001" blue="0.84313725490000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="Au3-hK-Z2q"/>
@@ -71,7 +71,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fre-XY-Ut7">
-                                <rect key="frame" x="87" y="461" width="200" height="40"/>
+                                <rect key="frame" x="87.5" y="461" width="200" height="40"/>
                                 <color key="backgroundColor" red="0.15686274510000001" green="0.65490196079999996" blue="0.27058823529999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="QCA-WD-Hwk"/>
@@ -84,13 +84,27 @@
                                     <action selector="onInfo:" destination="osO-Rp-nHh" eventType="touchUpInside" id="snx-1j-F51"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nbe-Gl-p8R">
+                                <rect key="frame" x="87.5" y="413" width="200" height="40"/>
+                                <color key="backgroundColor" red="0.6888468861579895" green="0.13919923262595113" blue="0.11669686631770547" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Alert"/>
+                                <connections>
+                                    <action selector="onError:" destination="osO-Rp-nHh" eventType="touchUpInside" id="Y5c-7k-Dnv"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="nbe-Gl-p8R" firstAttribute="height" secondItem="fre-XY-Ut7" secondAttribute="height" id="6Uc-X6-YOh"/>
                             <constraint firstItem="cyn-cy-XfB" firstAttribute="top" secondItem="fre-XY-Ut7" secondAttribute="bottom" constant="17" id="Mqa-gD-hxc"/>
+                            <constraint firstItem="fre-XY-Ut7" firstAttribute="top" secondItem="nbe-Gl-p8R" secondAttribute="bottom" constant="8" symbolic="YES" id="Qjs-ua-CcL"/>
                             <constraint firstItem="cyn-cy-XfB" firstAttribute="centerX" secondItem="83i-eb-xa2" secondAttribute="centerX" id="a9J-3N-hfT"/>
                             <constraint firstItem="spO-UG-XJt" firstAttribute="bottom" secondItem="cyn-cy-XfB" secondAttribute="bottom" constant="16" id="bac-or-OqW"/>
+                            <constraint firstItem="nbe-Gl-p8R" firstAttribute="centerX" secondItem="spO-UG-XJt" secondAttribute="centerX" id="d0F-bo-B1S"/>
                             <constraint firstItem="fre-XY-Ut7" firstAttribute="centerX" secondItem="83i-eb-xa2" secondAttribute="centerX" id="peT-XK-JaL"/>
+                            <constraint firstItem="nbe-Gl-p8R" firstAttribute="width" secondItem="fre-XY-Ut7" secondAttribute="width" id="wUt-jh-00O"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="spO-UG-XJt"/>
                     </view>

--- a/Examples/Examples/ViewController.swift
+++ b/Examples/Examples/ViewController.swift
@@ -12,7 +12,14 @@ import Squawk
 class ViewController: UIViewController {
 
     func reporter(errorConfig: Squawk.ErrorConfiguration) {
-        print("Logging error....")
+        print("Error: \(errorConfig.message)")
+
+        guard let file = errorConfig.file,
+            let function = errorConfig.function,
+            let line = errorConfig.line else  { return }
+        print("File: ", file)
+        print("Function: ", function)
+        print("Line: ", line)
     }
 
     override func viewDidLoad() {
@@ -35,8 +42,23 @@ class ViewController: UIViewController {
     }
 
     @IBAction func onError(_ sender: Any) {
-        Squawk.shared.showAndLogError(config: Squawk.Configuration(text: "Bad credentials"), errorConfig: Squawk.ErrorConfiguration(message: "Bad", file: #file, line: #line, function: #function))
+        Squawk.shared.showAndLogError(
+            config: Squawk.Configuration(
+                text: "Bad credentials"
+            ),
+            errorConfig: Squawk.ErrorConfiguration(
+                message: """
+Although you appear to have the correct authorization credentials,
+the GitHawkApp organization has enabled OAuth App access restrictions, meaning that data
+access to third-parties is limited. For more information on these restrictions, including
+how to whitelist this app, visit
+https://help.github.com/articles/restricting-access-to-your-organization-s-data/
+""",
+                file: #file,
+                line: #line,
+                function: #function
+            )
+        )
     }
-
 }
 

--- a/Examples/Examples/ViewController.swift
+++ b/Examples/Examples/ViewController.swift
@@ -11,6 +11,14 @@ import Squawk
 
 class ViewController: UIViewController {
 
+    func reporter(message: String) {
+        print("Logging error....")
+    }
+
+    override func viewDidLoad() {
+        Squawk.shared.configureErrorReporter(with: reporter)
+    }
+
     @IBAction func onInfo(_ sender: Any) {
         Squawk.shared.show(config: Squawk.Configuration(
             text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
@@ -24,6 +32,15 @@ class ViewController: UIViewController {
             buttonTapHandler: {
                 print("did tap info button")
         }))
+    }
+
+    @IBAction func onError(_ sender: Any) {
+        Squawk.shared.showAndLogError(
+            config: Squawk.Configuration(
+                text: "Your network seems to be down"
+            ),
+            errorMessage: "An error occured"
+        )
     }
 
 }

--- a/Examples/Examples/ViewController.swift
+++ b/Examples/Examples/ViewController.swift
@@ -11,7 +11,7 @@ import Squawk
 
 class ViewController: UIViewController {
 
-    func reporter(message: String) {
+    func reporter(errorConfig: Squawk.ErrorConfiguration) {
         print("Logging error....")
     }
 
@@ -35,12 +35,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func onError(_ sender: Any) {
-        Squawk.shared.showAndLogError(
-            config: Squawk.Configuration(
-                text: "Your network seems to be down"
-            ),
-            errorMessage: "An error occured"
-        )
+        Squawk.shared.showAndLogError(config: Squawk.Configuration(text: "Bad credentials"), errorConfig: Squawk.ErrorConfiguration(message: "Bad", file: #file, line: #line, function: #function))
     }
 
 }

--- a/Examples/Podfile.lock
+++ b/Examples/Podfile.lock
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../Squawk.podspec"
 
 SPEC CHECKSUMS:
-  Squawk: ced86daf8ad0465a67b1f3f40dc655323fc89d8a
+  Squawk: 87330be920de0474a907b4a39ab39e1c7db9aab2
 
 PODFILE CHECKSUM: 5dc59d90da9b2a2290f6f9a5fe6a6f7caaf8a4d0
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.5.0

--- a/Examples/Pods/Local Podspecs/Squawk.podspec.json
+++ b/Examples/Pods/Local Podspecs/Squawk.podspec.json
@@ -10,7 +10,7 @@
   },
   "summary": "Quick & interactive alerts.",
   "source": {
-    "git": "https://github.com/GitHawkApp/Squawk.git",
+    "git": "https://github.com/ehudadler/Squawk.git",
     "tag": "0.1.0"
   },
   "source_files": "Source/*.swift",

--- a/Examples/Pods/Manifest.lock
+++ b/Examples/Pods/Manifest.lock
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../Squawk.podspec"
 
 SPEC CHECKSUMS:
-  Squawk: ced86daf8ad0465a67b1f3f40dc655323fc89d8a
+  Squawk: 87330be920de0474a907b4a39ab39e1c7db9aab2
 
 PODFILE CHECKSUM: 5dc59d90da9b2a2290f6f9a5fe6a6f7caaf8a4d0
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.5.0

--- a/Examples/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,28 +7,28 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0BE6ED0850A6609B563986FBC29D061A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
-		1E2C56A3C338C073E420E964A8B24206 /* SquawkViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CA243A93B1B7E09DA1DC7D5932805 /* SquawkViewDelegate.swift */; };
-		1ECC49EA8C528B2F65008EA0D35786C8 /* RubberBandDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0AEE61C4838723C1B1F39463CDFAF5 /* RubberBandDistance.swift */; };
-		5057016260DBCF878D924B09C3C78003 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
-		574F47E4B296341C803AB76B7974A160 /* Pods-Examples-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 088CE4DEBD5AFD36D1D4293911018293 /* Pods-Examples-dummy.m */; };
-		7BE119CC992A4A047B5314C9A0FBD033 /* Squawk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE1343651DF65D93FCE00E074CAEF1F /* Squawk.swift */; };
-		84549F9CE8AEE84C512749969241F743 /* SquawkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A016A06C91453AC38504A32C0DD4E741 /* SquawkView.swift */; };
-		883D155741524A57B41C88DB23EA7DEF /* Pods-Examples-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 708CE1D611334D20D20054A47B165A45 /* Pods-Examples-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		96D5A028D56D042A616F1115202424A0 /* UIViewController+SearchChildren.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F35036694E0F56D248E497CB22D0D6 /* UIViewController+SearchChildren.swift */; };
-		B806222F831E2DE4C8C7CFAE70A57336 /* Anchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B0C20712E9AD7E0ADAA1F043B63D5 /* Anchor.swift */; };
-		CBCB36E9AA74C721DA2B4FC646F22EA2 /* Squawk-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AA39A859B6FF6C02633A9EF9196D86E /* Squawk-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D94C8EAF577A1A04C23D54B3F2F7ED11 /* Squawk+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE116F7D437E77AC722EF150A5E70BE /* Squawk+Configuration.swift */; };
-		F51D5D795723A9E6C866BA86C19E66F0 /* SquawkItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A62EB7420AEFE5BF047346D00AA188 /* SquawkItem.swift */; };
-		FC11C3BE95599F659162EAF769662C16 /* Squawk-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B0C7FFA8CACF8E49BD5938A6BCD72DF /* Squawk-dummy.m */; };
+		2FFBA37809F820CB3791D9F4D2686993 /* Squawk-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AA39A859B6FF6C02633A9EF9196D86E /* Squawk-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		447177B93F4D945FA7593382FB455E10 /* RubberBandDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0AEE61C4838723C1B1F39463CDFAF5 /* RubberBandDistance.swift */; };
+		6475BCC8FAD34409F9EC9281ED56855A /* Pods-Examples-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 088CE4DEBD5AFD36D1D4293911018293 /* Pods-Examples-dummy.m */; };
+		6EB5087D98E174F87F1375A1D369994F /* SquawkViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CA243A93B1B7E09DA1DC7D5932805 /* SquawkViewDelegate.swift */; };
+		717EEDC2C286A31D9B68C19B44D01CC5 /* Squawk-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B0C7FFA8CACF8E49BD5938A6BCD72DF /* Squawk-dummy.m */; };
+		72CD74DF29D728501CEA5AD664B568C7 /* SquawkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A016A06C91453AC38504A32C0DD4E741 /* SquawkView.swift */; };
+		866B18C18869E2DA7386375ED240A2D4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
+		9A688DA418203E9B6B69B492D54F96F0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
+		9C05869412AD24713344506820D9FE88 /* Squawk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE1343651DF65D93FCE00E074CAEF1F /* Squawk.swift */; };
+		A622CE67BAEE2FB22562C7726AF60411 /* Anchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B0C20712E9AD7E0ADAA1F043B63D5 /* Anchor.swift */; };
+		B6BF629D3A39A81E69EF2B80EE553C89 /* Pods-Examples-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 708CE1D611334D20D20054A47B165A45 /* Pods-Examples-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3F57E572CA6E3B5F392F54478A01298 /* Squawk+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE116F7D437E77AC722EF150A5E70BE /* Squawk+Configuration.swift */; };
+		C95E21B31CE229168D58E7DADCAA125B /* SquawkItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A62EB7420AEFE5BF047346D00AA188 /* SquawkItem.swift */; };
+		D22696DD26C5B2D6B29F5F02247EF7AF /* UIViewController+SearchChildren.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F35036694E0F56D248E497CB22D0D6 /* UIViewController+SearchChildren.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		FE238E80998D43D7C5C844719CD71182 /* PBXContainerItemProxy */ = {
+		7FD31BD23DD9279A19F7FA2262F5B068 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = B320C2A7D48CBEE840AA78C6BE3D7700;
+			remoteGlobalIDString = 1A98729508CC19CFE219554027F961B4;
 			remoteInfo = Squawk;
 		};
 /* End PBXContainerItemProxy section */
@@ -68,19 +68,19 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		3354E963B603A35D15A73AA4D3700D28 /* Frameworks */ = {
+		62217E271BD3982B6B5F8D7BB24A72FD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BE6ED0850A6609B563986FBC29D061A /* Foundation.framework in Frameworks */,
+				9A688DA418203E9B6B69B492D54F96F0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EA57F17F2A9365A469E47DB2A912BF40 /* Frameworks */ = {
+		7C13942EFDCCF3867B0617D2F332DA2F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5057016260DBCF878D924B09C3C78003 /* Foundation.framework in Frameworks */,
+				866B18C18869E2DA7386375ED240A2D4 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,50 +202,33 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		CF3ED33F09C459A00D725CCB32B06A6C /* Headers */ = {
+		4C40B63E5F8BCE0A523A05B73C6027E6 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CBCB36E9AA74C721DA2B4FC646F22EA2 /* Squawk-umbrella.h in Headers */,
+				B6BF629D3A39A81E69EF2B80EE553C89 /* Pods-Examples-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E70E07A0D17D13FED6E1320B2DEA32F3 /* Headers */ = {
+		AF09BE6AB3B22806B1F7A81CDE899012 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				883D155741524A57B41C88DB23EA7DEF /* Pods-Examples-umbrella.h in Headers */,
+				2FFBA37809F820CB3791D9F4D2686993 /* Squawk-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		5F792BF49593062227BFB2FA050172C3 /* Pods-Examples */ = {
+		1A98729508CC19CFE219554027F961B4 /* Squawk */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7944956D5F209FA05238CEDE0919F64C /* Build configuration list for PBXNativeTarget "Pods-Examples" */;
+			buildConfigurationList = 127500FD16541BFD4726E75FAEB8D663 /* Build configuration list for PBXNativeTarget "Squawk" */;
 			buildPhases = (
-				0DFF35BA76155C6C3CE7D823CBD3E33C /* Sources */,
-				EA57F17F2A9365A469E47DB2A912BF40 /* Frameworks */,
-				E70E07A0D17D13FED6E1320B2DEA32F3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				3CF0A7D448EEBE3A160EE837CAA23F32 /* PBXTargetDependency */,
-			);
-			name = "Pods-Examples";
-			productName = "Pods-Examples";
-			productReference = FA2566DAE3B7661F974DF773E3B5172E /* Pods_Examples.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		B320C2A7D48CBEE840AA78C6BE3D7700 /* Squawk */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 2A6D047971A219A4B09A56E3A4D44094 /* Build configuration list for PBXNativeTarget "Squawk" */;
-			buildPhases = (
-				68F648EF5C083201897D123BB6CC31BF /* Sources */,
-				3354E963B603A35D15A73AA4D3700D28 /* Frameworks */,
-				CF3ED33F09C459A00D725CCB32B06A6C /* Headers */,
+				AF09BE6AB3B22806B1F7A81CDE899012 /* Headers */,
+				036BCF4E7F4525C0D33A5F7AC4B1F773 /* Sources */,
+				7C13942EFDCCF3867B0617D2F332DA2F /* Frameworks */,
+				D27F037460CA34DF9FACA370D6A7BC5F /* Resources */,
 			);
 			buildRules = (
 			);
@@ -254,6 +237,25 @@
 			name = Squawk;
 			productName = Squawk;
 			productReference = 13EB50F2F2777D6407B5E4B6F5E4D837 /* Squawk.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C94736A5B832ADDCCC48E76E0DC93F08 /* Pods-Examples */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BFF9434CDAC2CC71E31D1BEC3C9CDAE8 /* Build configuration list for PBXNativeTarget "Pods-Examples" */;
+			buildPhases = (
+				4C40B63E5F8BCE0A523A05B73C6027E6 /* Headers */,
+				56F8053D06D8E6483EE8EAB221A0973C /* Sources */,
+				62217E271BD3982B6B5F8D7BB24A72FD /* Frameworks */,
+				ADD460565CBB815FCF871246F2C33CEC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8FDDF56E259695777889A2EA7999B0A5 /* PBXTargetDependency */,
+			);
+			name = "Pods-Examples";
+			productName = "Pods-Examples";
+			productReference = FA2566DAE3B7661F974DF773E3B5172E /* Pods_Examples.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -277,111 +279,71 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				5F792BF49593062227BFB2FA050172C3 /* Pods-Examples */,
-				B320C2A7D48CBEE840AA78C6BE3D7700 /* Squawk */,
+				C94736A5B832ADDCCC48E76E0DC93F08 /* Pods-Examples */,
+				1A98729508CC19CFE219554027F961B4 /* Squawk */,
 			);
 		};
 /* End PBXProject section */
 
-/* Begin PBXSourcesBuildPhase section */
-		0DFF35BA76155C6C3CE7D823CBD3E33C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
+/* Begin PBXResourcesBuildPhase section */
+		ADD460565CBB815FCF871246F2C33CEC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				574F47E4B296341C803AB76B7974A160 /* Pods-Examples-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		68F648EF5C083201897D123BB6CC31BF /* Sources */ = {
+		D27F037460CA34DF9FACA370D6A7BC5F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		036BCF4E7F4525C0D33A5F7AC4B1F773 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B806222F831E2DE4C8C7CFAE70A57336 /* Anchor.swift in Sources */,
-				1ECC49EA8C528B2F65008EA0D35786C8 /* RubberBandDistance.swift in Sources */,
-				D94C8EAF577A1A04C23D54B3F2F7ED11 /* Squawk+Configuration.swift in Sources */,
-				FC11C3BE95599F659162EAF769662C16 /* Squawk-dummy.m in Sources */,
-				7BE119CC992A4A047B5314C9A0FBD033 /* Squawk.swift in Sources */,
-				F51D5D795723A9E6C866BA86C19E66F0 /* SquawkItem.swift in Sources */,
-				84549F9CE8AEE84C512749969241F743 /* SquawkView.swift in Sources */,
-				1E2C56A3C338C073E420E964A8B24206 /* SquawkViewDelegate.swift in Sources */,
-				96D5A028D56D042A616F1115202424A0 /* UIViewController+SearchChildren.swift in Sources */,
+				A622CE67BAEE2FB22562C7726AF60411 /* Anchor.swift in Sources */,
+				447177B93F4D945FA7593382FB455E10 /* RubberBandDistance.swift in Sources */,
+				C3F57E572CA6E3B5F392F54478A01298 /* Squawk+Configuration.swift in Sources */,
+				717EEDC2C286A31D9B68C19B44D01CC5 /* Squawk-dummy.m in Sources */,
+				9C05869412AD24713344506820D9FE88 /* Squawk.swift in Sources */,
+				C95E21B31CE229168D58E7DADCAA125B /* SquawkItem.swift in Sources */,
+				72CD74DF29D728501CEA5AD664B568C7 /* SquawkView.swift in Sources */,
+				6EB5087D98E174F87F1375A1D369994F /* SquawkViewDelegate.swift in Sources */,
+				D22696DD26C5B2D6B29F5F02247EF7AF /* UIViewController+SearchChildren.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		56F8053D06D8E6483EE8EAB221A0973C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6475BCC8FAD34409F9EC9281ED56855A /* Pods-Examples-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		3CF0A7D448EEBE3A160EE837CAA23F32 /* PBXTargetDependency */ = {
+		8FDDF56E259695777889A2EA7999B0A5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Squawk;
-			target = B320C2A7D48CBEE840AA78C6BE3D7700 /* Squawk */;
-			targetProxy = FE238E80998D43D7C5C844719CD71182 /* PBXContainerItemProxy */;
+			target = 1A98729508CC19CFE219554027F961B4 /* Squawk */;
+			targetProxy = 7FD31BD23DD9279A19F7FA2262F5B068 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		08638A96A528B1EC32DE62F8A728389D /* Release */ = {
+		2544A3C745433B92EBF0BCC33BF6591B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 46F8A3D3F0984D3DA8E7A4D3DED400CC /* Pods-Examples.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_ALLOWED = NO;
-				CODE_SIGNING_REQUIRED = NO;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"POD_CONFIGURATION_RELEASE=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Release;
-		};
-		63418EB130A151F9B4B62C8DD8D86730 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 39C378211399DE8D28F6F815900B58CF /* Squawk.xcconfig */;
-			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -392,27 +354,28 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Squawk/Squawk-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Squawk/Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-Examples/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Squawk/Squawk.modulemap";
-				PRODUCT_MODULE_NAME = Squawk;
-				PRODUCT_NAME = Squawk;
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-Examples/Pods-Examples.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
-		6BC30DE010F2C5030CC1E2105C771281 /* Debug */ = {
+		653E3D7EA2AAFA17E323F736F750EC60 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 39C378211399DE8D28F6F815900B58CF /* Squawk.xcconfig */;
 			buildSettings = {
@@ -445,7 +408,7 @@
 			};
 			name = Debug;
 		};
-		804C223211B5BAFD2A9A12B1017A8852 /* Release */ = {
+		816CE7A6FB0D0465E3D5E9DB544F92BE /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DD4D1E3AFD802BF8F7580C35AF94D1BB /* Pods-Examples.release.xcconfig */;
 			buildSettings = {
@@ -473,7 +436,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -481,7 +445,42 @@
 			};
 			name = Release;
 		};
-		9DAE5233986C01ADB6E67169C53A3FD2 /* Debug */ = {
+		8B32768F4328BCA92BD057384C2CD8DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 39C378211399DE8D28F6F815900B58CF /* Squawk.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Squawk/Squawk-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Squawk/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Squawk/Squawk.modulemap";
+				PRODUCT_MODULE_NAME = Squawk;
+				PRODUCT_NAME = Squawk;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8C3D32AC054F4DBEE82EB2FD6A303D73 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -535,7 +534,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -544,50 +544,73 @@
 			};
 			name = Debug;
 		};
-		B7CF12E61D4073AA04A28FC1D1F44194 /* Debug */ = {
+		B751CA5B597BFC35A6C0287C65F9E2E1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 46F8A3D3F0984D3DA8E7A4D3DED400CC /* Pods-Examples.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-Examples/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"POD_CONFIGURATION_RELEASE=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-Examples/Pods-Examples.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
 			};
-			name = Debug;
+			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2A6D047971A219A4B09A56E3A4D44094 /* Build configuration list for PBXNativeTarget "Squawk" */ = {
+		127500FD16541BFD4726E75FAEB8D663 /* Build configuration list for PBXNativeTarget "Squawk" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6BC30DE010F2C5030CC1E2105C771281 /* Debug */,
-				63418EB130A151F9B4B62C8DD8D86730 /* Release */,
+				653E3D7EA2AAFA17E323F736F750EC60 /* Debug */,
+				8B32768F4328BCA92BD057384C2CD8DC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -595,17 +618,17 @@
 		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9DAE5233986C01ADB6E67169C53A3FD2 /* Debug */,
-				08638A96A528B1EC32DE62F8A728389D /* Release */,
+				8C3D32AC054F4DBEE82EB2FD6A303D73 /* Debug */,
+				B751CA5B597BFC35A6C0287C65F9E2E1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7944956D5F209FA05238CEDE0919F64C /* Build configuration list for PBXNativeTarget "Pods-Examples" */ = {
+		BFF9434CDAC2CC71E31D1BEC3C9CDAE8 /* Build configuration list for PBXNativeTarget "Pods-Examples" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B7CF12E61D4073AA04A28FC1D1F44194 /* Debug */,
-				804C223211B5BAFD2A9A12B1017A8852 /* Release */,
+				2544A3C745433B92EBF0BCC33BF6591B /* Debug */,
+				816CE7A6FB0D0465E3D5E9DB544F92BE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/Pods/Target Support Files/Pods-Examples/Pods-Examples-resources.sh
+++ b/Examples/Pods/Target Support Files/Pods-Examples/Pods-Examples-resources.sh
@@ -113,6 +113,6 @@ then
   if [ -z ${ASSETCATALOG_COMPILER_APPICON_NAME+x} ]; then
     printf "%s\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   else
-    printf "%s\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}" --app-icon "${ASSETCATALOG_COMPILER_APPICON_NAME}" --output-partial-info-plist "${TARGET_TEMP_DIR}/assetcatalog_generated_info_cocoapods.plist"
+    printf "%s\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}" --app-icon "${ASSETCATALOG_COMPILER_APPICON_NAME}" --output-partial-info-plist "${TARGET_BUILD_DIR}/assetcatalog_generated_info.plist"
   fi
 fi

--- a/Source/Squawk+Configuration.swift
+++ b/Source/Squawk+Configuration.swift
@@ -10,18 +10,24 @@ import UIKit
 
 public extension Squawk {
 
-
     public struct ErrorConfiguration {
-        let message: String
-        let file: String?
-        let line: String?
-        let function: String?
+        public let message: String
+        public let file: String?
+        public let line: String?
+        public let function: String?
+
+        public init(message: String) {
+            self.message = message
+            self.file = nil
+            self.line = nil
+            self.function = nil
+        }
 
         public init(
             message: String,
-            file: String? = "",
-            line: Int? = 0,
-            function: String? = ""
+            file: String,
+            line: Int,
+            function: String
             ) {
             self.message = message
             self.file = file
@@ -29,6 +35,7 @@ public extension Squawk {
             self.function = function
         }
     }
+
     public struct Configuration {
 
         let text: String
@@ -80,4 +87,5 @@ public extension Squawk {
     }
 
 }
+
 

--- a/Source/Squawk+Configuration.swift
+++ b/Source/Squawk+Configuration.swift
@@ -10,6 +10,25 @@ import UIKit
 
 public extension Squawk {
 
+
+    public struct ErrorConfiguration {
+        let message: String
+        let file: String?
+        let line: String?
+        let function: String?
+
+        public init(
+            message: String,
+            file: String?,
+            line: String?,
+            function: String?
+        ) {
+            self.message = message
+            self.file = file
+            self.line = line
+            self.function = function
+        }
+    }
     public struct Configuration {
 
         let text: String

--- a/Source/Squawk+Configuration.swift
+++ b/Source/Squawk+Configuration.swift
@@ -19,13 +19,13 @@ public extension Squawk {
 
         public init(
             message: String,
-            file: String?,
-            line: String?,
-            function: String?
-        ) {
+            file: String? = "",
+            line: Int? = 0,
+            function: String? = ""
+            ) {
             self.message = message
             self.file = file
-            self.line = line
+            self.line = String(describing: line)
             self.function = function
         }
     }
@@ -80,3 +80,4 @@ public extension Squawk {
     }
 
 }
+

--- a/Source/Squawk.swift
+++ b/Source/Squawk.swift
@@ -127,3 +127,4 @@ public class Squawk {
 
 }
 
+

--- a/Source/Squawk.swift
+++ b/Source/Squawk.swift
@@ -10,8 +10,9 @@ import UIKit
 
 public class Squawk {
 
+    typealias Reporter = (String) -> ()
     private var activeItem: SquawkItem?
-    private var errorReporter: (String) -> ()
+    private var errorReporter: Reporter?
 
     init() {
         NotificationCenter.default.addObserver(
@@ -36,12 +37,14 @@ public class Squawk {
         errorMessage: String
         ) {
         self.show(in: view, config: config)
-        errorReporter(errorMessage)
+
+        guard let reporter = errorReporter else  { return }
+        reporter(errorMessage)
     }
 
     public func show(
         in view: UIView? = nil,
-        config: Squawk.Configuration,
+        config: Squawk.Configuration
         ) {
         let viewToUse: UIView?
         if view == nil, let top = UIApplication.shared.keyWindow?.rootViewController?.topMostChild {
@@ -123,3 +126,4 @@ public class Squawk {
     }
 
 }
+

--- a/Source/Squawk.swift
+++ b/Source/Squawk.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class Squawk {
 
-    typealias Reporter = (String) -> ()
+    typealias Reporter = (Squawk.ErrorConfiguration) -> ()
     private var activeItem: SquawkItem?
     private var errorReporter: Reporter?
 
@@ -27,19 +27,19 @@ public class Squawk {
 
     public static let shared = Squawk()
 
-    public func configureErrorReporter(with reporter: @escaping (String) -> ()) {
+    public func configureErrorReporter(with reporter: @escaping (Squawk.ErrorConfiguration) -> ()) {
         errorReporter = reporter
     }
 
     public func showAndLogError(
         in view: UIView? = nil,
         config: Squawk.Configuration,
-        errorMessage: String
+        errorConfig: Squawk.ErrorConfiguration
         ) {
         self.show(in: view, config: config)
 
         guard let reporter = errorReporter else  { return }
-        reporter(errorMessage)
+        reporter(errorConfig)
     }
 
     public func show(

--- a/Source/Squawk.swift
+++ b/Source/Squawk.swift
@@ -11,6 +11,7 @@ import UIKit
 public class Squawk {
 
     private var activeItem: SquawkItem?
+    private var errorReporter: (String) -> ()
 
     init() {
         NotificationCenter.default.addObserver(
@@ -25,9 +26,22 @@ public class Squawk {
 
     public static let shared = Squawk()
 
+    public func configureErrorReporter(with reporter: @escaping (String) -> ()) {
+        errorReporter = reporter
+    }
+
+    public func showAndLogError(
+        in view: UIView? = nil,
+        config: Squawk.Configuration,
+        errorMessage: String
+        ) {
+        self.show(in: view, config: config)
+        errorReporter(errorMessage)
+    }
+
     public func show(
         in view: UIView? = nil,
-        config: Squawk.Configuration
+        config: Squawk.Configuration,
         ) {
         let viewToUse: UIView?
         if view == nil, let top = UIApplication.shared.keyWindow?.rootViewController?.topMostChild {

--- a/Squawk.podspec
+++ b/Squawk.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = 'https://github.com/GitHawkApp/Squawk'
   spec.authors      = { 'Ryan Nystrom' => 'rnystrom@whoisryannystrom.com' }
   spec.summary      = 'Quick & interactive alerts.'
-  spec.source       = { :git => 'https://github.com/GitHawkApp/Squawk.git', :tag => spec.version.to_s }
+  spec.source       = { :git => 'https://github.com/ehudadler/Squawk.git', :tag => spec.version.to_s }
   spec.source_files = 'Source/*.swift'
   spec.platform     = :ios, '11.0'
   spec.swift_version = '4.0'

--- a/Squawk.podspec
+++ b/Squawk.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = 'https://github.com/GitHawkApp/Squawk'
   spec.authors      = { 'Ryan Nystrom' => 'rnystrom@whoisryannystrom.com' }
   spec.summary      = 'Quick & interactive alerts.'
-  spec.source       = { :git => 'https://github.com/ehudadler/Squawk.git', :tag => spec.version.to_s }
+  spec.source       = { :git => 'https://github.com/GitHawkApp/Squawk.git', :tag => spec.version.to_s }
   spec.source_files = 'Source/*.swift'
   spec.platform     = :ios, '11.0'
   spec.swift_version = '4.0'


### PR DESCRIPTION
In GitHawk it is not uncommon to have an "Something went wrong" error. This error makes a bit of sense to show the user but is absolutely unhelpful to the developer. The user is informed that an error occurred but the developer has no way of helping solve it without asking a bunch of questions.

Anyway long story short. I think we can do better by adding a parameter to the Squawk show method (renamed to` showAndLogError` for error messages, `show` still exists). The parameter is of type Squawk.ErrorConfiguration which is a struct filled with the full error message along with `#line`, `#file` and `#function.` This parameter will get passed to the `Squawk.shared.reporter` which is a function that takes a parameter of type Squawk.ErrorConfiguration and allows the developer to decide how to handle it. One example would be passing it onto Fabric or Crash analytics etc. 


TODO:
- [ ] Add timestamp to issue
- [ ] Try to reduce the number of times "Reporter" function is called 
- [ ] Group duplicate errors into 1 report and assign the number of instances that error occurred rather than multiples   